### PR TITLE
Remove "with-sbt-classifiers" for sbt-idea for 0.10 and fix command for sbt-idea for 0.7.

### DIFF
--- a/sbt-plugin/src/main/resources/META-INF/plugin.xml
+++ b/sbt-plugin/src/main/resources/META-INF/plugin.xml
@@ -35,15 +35,15 @@
                 0.10.x Plugins Page</a>
                 as an SBT Plugin.
             </li>
-            <li>From a terminal, run <code>sbt "gen-idea with-sbt-classifiers"</code></li>
+            <li>From a terminal, run <code>sbt "gen-idea"</code></li>
             <li>This creates a .idea and .idea_modules folder with project configuration. Open the project with IDEA.</li>
-            <li>After each change to your dependencies, run <code>sbt "gen-idea with-sbt-classifiers"</code> and when prompted reload the project</li>
+            <li>After each change to your dependencies, run <code>sbt "gen-idea"</code> and when prompted reload the project</li>
         </ol>
 
         <ol>
             <dt><b>Creating/Updating IDEA project files (SBT 0.7.x)</b></dt>
             <li>(One time) Install <a href="https://github.com/mpeltonen/sbt-idea">sbt-idea</a> as an SBT Processor.</li>
-            <li>From a terminal, run <code>sbt "gen-idea with-sbt-classifiers"</code></li>
+            <li>From a terminal, run <code>sbt "idea"</code></li>
             <li>This creates a .idea folder with project configuration. Open the project with IDEA.</li>
             <li>After each change to your dependencies, run <code>sbt update idea</code> and when prompted reload the project</li>
         </ol>


### PR DESCRIPTION
"with-sbt-classifiers" doesn't work with SBT 0.10 and I intend to make it the default once SBT 0.10.1 is out. And the command for 0.7 was simply "idea", so fixed that too.
