### PR TITLE
Fix #92, rework execute action for ideavim

### DIFF
--- a/sbt-plugin/src/main/java/net/orfjackal/sbt/plugin/SbtActionPromoter.java
+++ b/sbt-plugin/src/main/java/net/orfjackal/sbt/plugin/SbtActionPromoter.java
@@ -1,0 +1,31 @@
+// Copyright © 2010-2014, Esko Luontola <www.orfjackal.net>
+// This software is released under the Apache License 2.0.
+// The license text is at http://www.apache.org/licenses/LICENSE-2.0
+
+package net.orfjackal.sbt.plugin;
+
+import com.intellij.openapi.actionSystem.ActionPromoter;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.DataContext;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * @author pfnguyen
+ */
+public class SbtActionPromoter implements ActionPromoter {
+    public List<AnAction> promote(List<AnAction> actions, DataContext context) {
+        for (AnAction action : actions) {
+
+            if (action instanceof SbtConsoleExecuteAction) {
+                List<AnAction> promoted = new ArrayList<AnAction>(1);
+                promoted.add(action);
+                return promoted;
+            }
+        }
+
+        return Collections.emptyList();
+    }
+}

--- a/sbt-plugin/src/main/java/net/orfjackal/sbt/plugin/SbtConsoleExecuteAction.java
+++ b/sbt-plugin/src/main/java/net/orfjackal/sbt/plugin/SbtConsoleExecuteAction.java
@@ -1,0 +1,73 @@
+// Copyright © 2010-2014, Esko Luontola <www.orfjackal.net>
+// This software is released under the Apache License 2.0.
+// The license text is at http://www.apache.org/licenses/LICENSE-2.0
+
+package net.orfjackal.sbt.plugin;
+
+import com.intellij.execution.console.LanguageConsoleImpl;
+import com.intellij.execution.process.ConsoleHistoryModel;
+import com.intellij.execution.process.ProcessHandler;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.CommonDataKeys;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.util.TextRange;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * @author pfnguyen
+ */
+public class SbtConsoleExecuteAction extends AnAction {
+    private static final Logger logger = Logger.getInstance(SbtConsoleExecuteAction.class.getName());
+    @Override
+    public void actionPerformed(@NotNull AnActionEvent e) {
+        final Editor editor = e.getData(CommonDataKeys.EDITOR);
+        if (editor == null) {
+            return;
+        }
+        final LanguageConsoleImpl console = SbtConsoleInfo.getConsole(editor);
+        final ProcessHandler processHandler = SbtConsoleInfo.getHandler(editor);
+        final ConsoleHistoryModel model = SbtConsoleInfo.getModel(editor);
+        if (console != null && processHandler != null && model != null) {
+            final Document document = console.getEditorDocument();
+            final String text = document.getText();
+
+            // Process input and add to history
+
+            ApplicationManager.getApplication().runWriteAction(new Runnable() {
+                public void run() {
+                    TextRange range = new TextRange(0, document.getTextLength());
+                    editor.getSelectionModel().setSelection(range.getStartOffset(), range.getEndOffset());
+                    console.addToHistory(range, console.getConsoleEditor(), true);
+                    model.addToHistory(text);
+
+                    editor.getCaretModel().moveToOffset(0);
+                    editor.getDocument().setText("");
+                }
+            });
+
+            for (String line : text.split("\n")) {
+                if (!line.equals("")) {
+                    OutputStream outputStream = processHandler.getProcessInput();
+                    try {
+                        byte[] bytes = (line + "\n").getBytes("utf-8");
+                        outputStream.write(bytes);
+                        outputStream.flush();
+                    } catch (IOException ex) {
+                        // noop
+                    }
+                }
+//                console.textSent(line + "\n");
+            }
+        } else {
+            logger.info(new Throwable("Enter action in console failed: $editor, " +
+                    "$console"));
+        }
+    }
+}

--- a/sbt-plugin/src/main/java/net/orfjackal/sbt/plugin/SbtConsoleExecuteAction.java
+++ b/sbt-plugin/src/main/java/net/orfjackal/sbt/plugin/SbtConsoleExecuteAction.java
@@ -14,6 +14,7 @@ import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.editor.ex.EditorEx;
 import com.intellij.openapi.util.TextRange;
 import org.jetbrains.annotations.NotNull;
 
@@ -25,6 +26,24 @@ import java.io.OutputStream;
  */
 public class SbtConsoleExecuteAction extends AnAction {
     private static final Logger logger = Logger.getInstance(SbtConsoleExecuteAction.class.getName());
+    @Override
+    public void update(@NotNull AnActionEvent e) {
+        Editor editor = e.getData(CommonDataKeys.EDITOR);
+        if (editor == null || !(editor instanceof EditorEx)) {
+            e.getPresentation().setEnabled(false);
+            return;
+        }
+        LanguageConsoleImpl console = SbtConsoleInfo.getConsole(editor);
+        if (console == null)  {
+            e.getPresentation().setEnabled(false);
+            return;
+        }
+        boolean isEnabled = !((EditorEx)editor).isRendererMode() &&
+                !SbtConsoleInfo.getHandler(editor).isProcessTerminated();
+
+        e.getPresentation().setEnabled(isEnabled);
+    }
+
     @Override
     public void actionPerformed(@NotNull AnActionEvent e) {
         final Editor editor = e.getData(CommonDataKeys.EDITOR);

--- a/sbt-plugin/src/main/java/net/orfjackal/sbt/plugin/SbtConsoleInfo.java
+++ b/sbt-plugin/src/main/java/net/orfjackal/sbt/plugin/SbtConsoleInfo.java
@@ -1,0 +1,93 @@
+// Copyright © 2010-2014, Esko Luontola <www.orfjackal.net>
+// This software is released under the Apache License 2.0.
+// The license text is at http://www.apache.org/licenses/LICENSE-2.0
+
+package net.orfjackal.sbt.plugin;
+
+import com.intellij.execution.console.LanguageConsoleImpl;
+import com.intellij.execution.process.ConsoleHistoryModel;
+import com.intellij.execution.process.ProcessHandler;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.project.Project;
+import com.intellij.util.containers.WeakHashMap;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author pfnguyen
+ */
+public class SbtConsoleInfo {
+    private static WeakHashMap<Project,List<ConsoleInfo>> allConsoles =
+            new WeakHashMap<Project,List<ConsoleInfo>>();
+
+    public static void addConsole(LanguageConsoleImpl console, ConsoleHistoryModel model, ProcessHandler handler) {
+        Project p = console.getProject();
+        List<ConsoleInfo> consoles = allConsoles.get(p);
+        if (consoles == null) {
+            consoles = new ArrayList<ConsoleInfo>();
+            allConsoles.put(p, consoles);
+        }
+        consoles.add(new ConsoleInfo(console, model, handler));
+    }
+
+    public static void disposeConsole(LanguageConsoleImpl console) {
+        Project p = console.getProject();
+        List<ConsoleInfo> consoles = allConsoles.get(p);
+        if (consoles != null) {
+            List<ConsoleInfo> copy = new ArrayList<ConsoleInfo>(consoles.size());
+            for (ConsoleInfo info : consoles) {
+                if (info.console != console)
+                    copy.add(info);
+            }
+            allConsoles.put(p, copy);
+        }
+    }
+
+    public static LanguageConsoleImpl getConsole(Editor e) {
+        Project p = e.getProject();
+        List<ConsoleInfo> consoles = allConsoles.get(p);
+        if (consoles != null) {
+            for (ConsoleInfo info : consoles) {
+                if (info.console.getConsoleEditor() == e)
+                    return info.console;
+            }
+        }
+        return null;
+    }
+    public static ProcessHandler getHandler(Editor e) {
+        Project p = e.getProject();
+        List<ConsoleInfo> consoles = allConsoles.get(p);
+        if (consoles != null) {
+            for (ConsoleInfo info : consoles) {
+                if (info.console.getConsoleEditor() == e)
+                    return info.handler;
+            }
+        }
+        return null;
+    }
+
+    public static ConsoleHistoryModel getModel(Editor e) {
+        Project p = e.getProject();
+        List<ConsoleInfo> consoles = allConsoles.get(p);
+        if (consoles != null) {
+            for (ConsoleInfo info : consoles) {
+                if (info.console.getConsoleEditor() == e)
+                    return info.model;
+            }
+        }
+        return null;
+    }
+
+    private static class ConsoleInfo {
+        public final LanguageConsoleImpl console;
+        public final ProcessHandler handler;
+        public final ConsoleHistoryModel model;
+
+        public ConsoleInfo(LanguageConsoleImpl console, ConsoleHistoryModel model, ProcessHandler handler) {
+            this.console = console;
+            this.handler = handler;
+            this.model = model;
+        }
+    }
+}

--- a/sbt-plugin/src/main/resources/META-INF/plugin.xml
+++ b/sbt-plugin/src/main/resources/META-INF/plugin.xml
@@ -84,6 +84,8 @@
         <completion.contributor language="TEXT" implementationClass="net.orfjackal.sbt.plugin.sbtlang.SbtCompletionContributor"/>
         <lang.fileViewProviderFactory language="SBT"
                                               implementationClass="net.orfjackal.sbt.plugin.sbtlang.SbtFileViewProviderFactory"/>
+
+        <actionPromoter implementation="net.orfjackal.sbt.plugin.SbtActionPromoter"/>
     </extensions>
 
     <project-components>
@@ -102,5 +104,10 @@
             <implementation-class>net.orfjackal.sbt.plugin.settings.SbtApplicationSettingsComponent</implementation-class>
         </component>
     </application-components>
+    <actions>
+        <action id="SbtConsole.Execute" class="net.orfjackal.sbt.plugin.SbtConsoleExecuteAction">
+            <keyboard-shortcut first-keystroke="ENTER" keymap="$default"/>
+        </action>
+    </actions>
 
 </idea-plugin>


### PR DESCRIPTION
mimics how intellij-scala handles ScalaConsoleExecuteAction
see https://github.com/JetBrains/intellij-scala/tree/master/src/org/jetbrains/plugins/scala/console

I have only tested this on IntelliJ 14 and with IdeaVIM enabled. Other configurations need to be tested as well.