### PR TITLE
Fix and improve error reporting when sbt start fails

### DIFF
--- a/sbt-plugin/src/main/java/net/orfjackal/sbt/plugin/SbtConsole.java
+++ b/sbt-plugin/src/main/java/net/orfjackal/sbt/plugin/SbtConsole.java
@@ -200,7 +200,7 @@ public class SbtConsole {
 
         @Override
         public void actionPerformed(AnActionEvent event) {
-            runnerComponent.startIfNotStartedSafe(false);
+            runnerComponent.startIfNotStartedSafe(false, null);
         }
 
         @Override


### PR DESCRIPTION
When `startIfNotStarted` failed for any reason while on background thread (for example when building from run configuration), error report would fail ([trace](http://pastebin.com/eXww7S8F)). This PR fixes this crash by handling UI explicitly on UI thread and improves UX by showing what was SBT started for.

(Action info would not be that important, but since the plugin calls `startIfNotStartedSafe` three times in succession, three identical error notifications were strange.)

When SBT fails to start when starting the SBT console, the notification is visually the same (small popup from the bottom bar), but standard notification balloon is shown when the error is during pre-run.